### PR TITLE
fix hub url

### DIFF
--- a/docs/hub.mdx
+++ b/docs/hub.mdx
@@ -14,4 +14,4 @@ The Hub is the central place within the app where you can:
 - See notifications for active proposals in your DAOs
 - See recent activity within your DAOs
 
-> Pro tip: bookmark https://daohaus.gg to head straight to your Hub ;)
+> Pro tip: bookmark daohaus.gg to head straight to your Hub ;)


### PR DESCRIPTION
daohaus.gg doesn't work with https://, so this removes it