### PR TITLE
added Discord subsection

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -65,6 +65,7 @@ module.exports = {
       "users/uberhaus-faq",
       "users/minion-faq",
       "users/other-networks-faq",
+      "users/discord-faq"
     ],
   },
    


### PR DESCRIPTION
Added Discord FAQ section, as there's FAQ relating to Discord specifically (e.g. how to tip HAUS) 

This should go into the handbook section eventually though. FAQ is just placeholder until we restructure the documentation. 