### PR TITLE
Documentation fixed spelling, formatting

### DIFF
--- a/docs/devs/goals-and-ideals.mdx
+++ b/docs/devs/goals-and-ideals.mdx
@@ -7,35 +7,35 @@ slug: /devs/goals-and-ideals
 
 import Link from "@docusaurus/Link";
 
-- Organize the app to make it easier to debug, maintain, and integrate new functionality
+- Organize the app to make it easier to debug, maintain, and integrate new functionality.
 - Create a common code paradigm used by all devs on the team.
 - Share the rules of this paradigm to make it easier for new devs to contribute lasting code.
-- Make code more consistent and readable
+- Make code more consistent and readable.
 - Make it easier to debug.
 
 ### Overarching Ideals
 
 - Less code. Perform the greatest amount of work with the least amount of expression.
 - Less state. Strive to eliminate excess state wherever possible.
-- DRY
+- DRY.
 - Functional is generally preferred over Object Oriented.
 - No hard rules. Devs should be free to break any rule at any time. However, if they do wish to break a rule, they should outline their reasoning in a comment.
-- Any major changes or new patterns should be posted in #code-review on Discord
+- Any major changes or new patterns should be posted in #code-review on <a href="https://discord.com/invite/daohaus"> Discord </a>.
 - Clean as you go. Devs rarely refactor code months later, despite their best intentions. So it's best to deliver clean code from the outset.
 - Criticism and review should be frequent and good-spirited.
 - This is an ongoing process. We need to debate and discuss these rules in order to improve them.
 
 ### Review Process
 
-- TBD (meeting, Pull request)
+- TBD (meeting, Pull request).
 
 ### Style guide
 
-Our linter is currently set to adhere to the <a href="https://airbnb.io/javascript/">AirBNB JS Style guide </a>
+- Our linter is currently set to adhere to the <a href="https://airbnb.io/javascript/">AirBNB JS Style guide </a>.
 
 ### New Devs
 
-- To save yourself some time, read through the review guidelines thoroughly
+- To save yourself some time, read through the review guidelines thoroughly.
 - Learn the <Link to='/docs/devs/contexts'>structure of the app </Link>.
 - If you're tasked with interacting with a contract (TXs), learn the <Link to='/docs/devs/tx-polling'>TX/polling/test cycle </Link>.
 - Brush up on React by scouring the docs. Familiarize yourself with some of the more advanced aspects of hooks, contexts, and lazy-loading.

--- a/docs/devs/legos/field.mdx
+++ b/docs/devs/legos/field.mdx
@@ -22,18 +22,18 @@ This value tells the factory component what to render as the input's label.
 
 This is the 'key' or 'id' for the data enterred into the input. This value: 
 
-- Must be different than any other ``name`` values on the form
-- Stores data in the ``values`` object under the key enterred as ``name``
-- Which means that this is the reference to the data the user provides in the input
-- It's used inside the TX data to get form data into the transaction
-- It's what the Form.required checks for 
-- can be referenced throughout the transaction process by the name enterred here. 
+- Must be different than any other ``name`` values on the form.
+- Stores data in the ``values`` object under the key enterred as ``name``.
+- Which means that this is the reference to the data the user provides in the input.
+- It's used inside the TX data to get form data into the transaction.
+- It's what the Form.required checks for. 
+- Can be referenced throughout the transaction process by the name entered here. 
 
 #### Field.htmlFor
 
 (String)
 
-Links the input's name with it's label. For accessibility purposes. If falsy, the htmlFor will default to the input's name. 
+Links the input's name with its label for accessibility purposes. If falsy, the htmlFor will default to the input's name. 
 
 #### Field.placeholder
 
@@ -45,7 +45,7 @@ Placeholder text for the input.
 
 (String)
 
-if a field lego recieves a ``field.info`` value, the component's wrapper will display an info icon, with a hoverable tooltip that displays the string value enterred in the ``info`` field. 
+If a field lego recieves a ``field.info`` value, the component's wrapper will display an info icon, with a hoverable tooltip that displays the string value enterred in the ``info`` field. 
 
 If field.info is falsy or not included in the lego, an info tooltip does not render. 
 
@@ -53,7 +53,7 @@ If field.info is falsy or not included in the lego, an info tooltip does not ren
 
 (String)
 
-This tells the form validation what type of string this input is expecting. Becuase all incoming data from inputs are strings, **expectType does not check for JS types, instead it looks for different types of strings**. 
+This tells the form validation what type of string this input is expecting. Because all incoming data from inputs are strings, **expectType does not check for JS types, instead it looks for different types of strings**. 
 
 For example, if we had an input that was only expecting numbers, both integers and numbers with decimals, Field.expectType would equal ``number``. The validation would then look at the string the input recieves and check if all the characters in the string are all numbers. 
 

--- a/docs/devs/legos/overview.mdx
+++ b/docs/devs/legos/overview.mdx
@@ -8,9 +8,9 @@ Code legos are small packets of static data written in Javascript. Essentially, 
 
 ## Why Code Legos
 - Speed up and simplify the flow of boost development. 
-- Drastically reduce the amount of code the application needs to store
-- Create building blocks that are composable with others
-- To make the app more interopable with potential backend architecture (ex. DAOhaus Marketplace, DAOhaus API, Boost APIs)
+- Drastically reduce the amount of code the application needs to store.
+- Create building blocks that are composable with others.
+- Make the app more interopable with potential backend architecture (ex. DAOhaus Marketplace, DAOhaus API, Boost APIs).
 - Remove the need for community developers to alter the core application architecture.
 - Maintain consistent patterns and types across the app that can be easily tested and maintained.  
 - Better tools for DAO devs so they can create better tools for DAO communities. 

--- a/docs/devs/legos/tx-tut.mdx
+++ b/docs/devs/legos/tx-tut.mdx
@@ -46,7 +46,7 @@ PROPOSAL_FORMS: {
 }
 ```
 
-Becuase the Form lego composes the tx lego, and it has its own way of firing off transactions, the dev never has to introduce the transaction to a react component at all. 
+Because the Form lego composes the tx lego, and it has its own way of firing off transactions, the dev never has to introduce the transaction to a react component at all. 
 
 With JS Legos, devs are able to create their transactions as clean, static data. This will allow core devs to store, compose, and organize the applications functionality as they please, while allowing community devs a flexible yet concise interface for boost development. 
 
@@ -58,7 +58,7 @@ With JS Legos, devs are able to create their transactions as clean, static data.
 
 ## Tutorial 
 
-However, there are many cases where transactions will still need to placed in a React component. 
+However, there are many cases where transactions will still need to be placed in a React component. 
 
 Let's go through an example. Let's say we want to wire up a button to sponsor a proposal when the user clicks it. 
 
@@ -75,10 +75,10 @@ TX:{
 }
 ```
 
-Then we want to direct this transaction by telling it which contract ABI to interact with and what function to call. For this transaction, we're calling the DAO's Moloch contract. So we'll use the string 'Moloch' under the field `contract` 
+Then we want to direct this transaction by telling it which contract ABI to interact with and what function to call. For this transaction, we're calling the DAO's Moloch contract. So we'll use the string 'Moloch' under the field `contract`.
 
 - We have a Contract Service to interact with this ABI already.
-- So all we need to do is travel to MolochService.js in src/services and find the function that we want to hit. In this case, the name is ``sponsorProposal``
+- So all we need to do is travel to MolochService.js in `src/services` and find the function that we want to hit. In this case, the name is ``sponsorProposal``
 - Let's add these to the Lego: 
 
 ```js
@@ -90,7 +90,7 @@ TX:{
 }
 ```
 
-Note: *At the moment, TXlegos only interact with local ABIs through contract services. In the future, we will dynamically fetch network ABIs from block explorers. Services will also be phased out to ensure a single source of truth*
+Note: *At the moment, TXlegos only interact with local ABIs through contract services. In the future, we will dynamically fetch network ABIs from block explorers. Services will also be phased out to ensure a single source of truth*.
 
 Next we'll need to tell the app what to poll to ensure that UI only updates once all the backend data has been updated. We're interacting with the DAOhaus subgraph, so all we need to add is 'subgraph' to the `poll` field. 
 
@@ -142,7 +142,7 @@ TX:{
 }
 ```
 
-Becuase we'll be adding the function arguments inside the transaction itself, this lego is finished. All we need to do is hook it up. 
+Because we'll be adding the function arguments inside the transaction itself, this lego is finished. All we need to do is hook it up. 
 
 ```js
 //  in src/components/proposalActions.js

--- a/docs/devs/legos/tx.mdx
+++ b/docs/devs/legos/tx.mdx
@@ -76,27 +76,27 @@ String for displaying the current transaction to users. Will be used in txList a
 
 (STRING)
 
-String that is displayed in the success toast when the transaction completes
+String that is displayed in the success toast when the transaction completes.
 
 #### tx.errMsg 
 
 (STRING)
 
-String that is displayed in the err toast when the transaction completes
+String that is displayed in the err toast when the transaction completes.
 
 #### tx.detailsToJSON 
 
 (Array of Strings)
 
-PROPOSAL_FORMS (and likely other transactions) require a `details` field to hold arbitrary JSON data. However, the app relies on this field to deliver consistent UI to the app. Becuase the data in this field is immutable, there are considerable consequences for passing data in here the wrong way. 
+PROPOSAL_FORMS (and likely other transactions) require a `details` field to hold arbitrary JSON data. However, the app relies on this field to deliver consistent UI to the app. Because the data in this field is immutable, there are considerable consequences for passing data in here the wrong way. 
 
-The solution is have a premade API handle it. So now each transaction that has a details JSON string as an argument will use the detailsJSON field on its TX object. 
+The solution is to have a premade API to handle it. So now each transaction that has a details JSON string as an argument will use the detailsJSON field on its TX object. 
 
 This field: 
-- Takes an array of strings
-- searches the `values` object for fields with the same name as those strings. 
-- copies those fields into a new object
-- stringifies that object and turns and passes it to the argument slot as directed by the gatherArgs field. 
+- Takes an array of strings.
+- Searches the `values` object for fields with the same name as those strings. 
+- Copies those fields into a new object.
+- Stringifies that object and turns and passes it to the argument slot as directed by the gatherArgs field. 
 
 Also: 
 - To keep the shape of detailsToJSON strings consistent, there is a DETAILS constant inside of ``contractTX.js``. 
@@ -135,11 +135,11 @@ ex.
 ##### Deep Search (application-wide)
 
 Uses it's own search notation to find application state for within the React Context stores. 
-- Exists in a search param object
+- Exists in a search param object.
 - Initiated by using 'search' in the `type` field. 
-- depth of the search is controlled by an array that looks for nested fields with a matching name (can also do numerical array values)
-- Requires a strong understanding of the application data structure
-- To be used in the most tricky situations 
+- Depth of the search is controlled by an array that looks for nested fields with a matching name (can also do numerical array values).
+- Requires a strong understanding of the application data structure.
+- To be used in the most tricky situations. 
 
 ex. 
 ```
@@ -151,8 +151,8 @@ ex.
 ```
 ##### Static values
 For hardcoded static values. 
-- Exists in a search param object
-- Initiated by using the keyword 'static' in the field `type`
+- Exists in a search param object.
+- Initiated by using the keyword 'static' in the field `type`.
 
 ex. 
 ```
@@ -169,8 +169,8 @@ Read more about how this works in tx.detailsJSON.
 
 ##### Mix'n Match Approach
 
-- Args don't need to be of one type
-- They can use any combination of search types 
+- Args don't need to be of one type.
+- They can use any combination of search types.
 ```
 gatherArgs: [
      {type: 'search', fields: ['contextData', 'daoOverview', 'depositToken']}, 
@@ -190,15 +190,15 @@ Indicates that args will not be gathered from either the React Component or usin
 Instead, this transaction will use a callback function that is declared inside of ``argBuilderCallback{}``inside of ``txHelpers.js``. 
 
 
-- Each field in this object is a callback function
-- The name of the callback function must be the same as the name of the transaction
-- Each callback has access to ``values``, ``tx``(tx lego data), contextData(application State) ``formData (form lego data)``, a ``hash``--each as named arguments. 
+- Each field in this object is a callback function.
+- The name of the callback function must be the same as the name of the transaction.
+- Each callback has access to ``values``, ``tx`` (tx lego data), ``contextData`` (application State) ``formData`` (form lego data), a ``hash``, each as named arguments. 
 
-Becuase these callbacks are non-composable, their uses are limited to: 
-- Fast protoyping (temporary; not pushed to prod)
-- last resort (no other option)
+Because these callbacks are non-composable, their uses are limited to: 
+- Fast protoyping (temporary; not pushed to prod).
+- last resort (no other option).
 
-In every case, a TXs arg from callback will eventually need to be refactored into static data--either through refactoring a fast protoype or improving the txLego system. 
+In every case, a TXs arg from callback will eventually need to be refactored into static data, either through refactoring a fast protoype or improving the txLego system. 
 
 #### createDiscourse
 

--- a/docs/devs/services.mdx
+++ b/docs/devs/services.mdx
@@ -7,11 +7,11 @@ slug: /devs/services
 
 ## Overview
 
-DAOhaus uses higher-order functions to make calls on contracts instead of JS classes. The goal of this pattern is to minimize state within the app as managing state between the contract, React's contexts, and JS classes (previously used for contract interaction) was challenging and sometimes difficult to follow.
+DAOhaus uses higher-order functions to make calls on contracts instead of JS classes. The goal of this pattern is to minimize the state within the app as managing the state between the contract, React's contexts, and JS classes (previously used for contract interaction) was challenging and sometimes difficult to follow.
 
-Each contract will usually curry three function calls from a service.
+Each contract will usually carry three function calls from a service.
 
-1. Instantion of a web3.js contract object
+1. Instantiation of a web3.js contract object.
 
 ```js
 await MolochService({
@@ -22,7 +22,7 @@ await MolochService({
 });
 ```
 
-2. Selection of service (function) on contract
+2. Selection of service (function) on contract.
 
 ```js
 await MolochService({

--- a/docs/devs/subgraphs.md
+++ b/docs/devs/subgraphs.md
@@ -7,7 +7,7 @@ slug: /devs/subgraphs
 
 ## What is TheGraph?
 
-The Graph is an indexing protocol that the incentivzes and coordinates indexing of public blockchain data.  The Graph provides queryable data using GraphQL for your API to plug into. By indexing Moloch contracts with The Graph any user with access to TheGraph can find data on all compatible DAOs instantly.
+The Graph is an indexing protocol that the incentivizes and coordinates indexing of public blockchain data. The Graph provides queryable data using GraphQL for your API to plug into. By indexing Moloch contracts with The Graph any user with an access to TheGraph can find data on all compatible DAOs instantly.
 
 ## Subgraphs
 
@@ -217,7 +217,7 @@ The primary DAOhaus subgraph tracks the primary entities of v1 and v2/2.1 DAOs: 
 
 ### Stats Subgraph
 
-The DAOhaus Stats Subgraph provides aggregated stats and metrics for users and communities across the platform.
+The DAOhaus Stats Subgraph provides aggregated statistics and metrics for users and communities across the platform.
 
 #### Moloches Stats
 

--- a/docs/devs/tx-polling.md
+++ b/docs/devs/tx-polling.md
@@ -21,7 +21,7 @@ Polls are used in the DAOhaus client to check and see if transactions are comple
 const poll = createPoll({ action: "submitProposal", cachePoll });
 ```
 
-It's important to note that PollServices are curried together the same way the ContractServices are. In the first pass, we're passing in a cachingFunction served from UserContext (TXs are saved in the users TX data). There are some optional arguments that can be passed in as well. These optional params control the interval and speed of the poll.
+It's important to note that PollServices are carried together the same way the ContractServices are. In the first pass, we're passing in a cachingFunction served from UserContext (TXs are saved in the users TX data). There are some optional arguments that can be passed in as well. These optional params control the interval and speed of the poll.
 
 Ex.
 


### PR DESCRIPTION
Following  the issue to improve the documentation https://github.com/HausDAO/haus-tasks/issues/6. First fixed misspellings and improved formatting.