### PR TITLE
Update DAOhaus Discord link

### DIFF
--- a/docs/users/settings-faq.mdx
+++ b/docs/users/settings-faq.mdx
@@ -8,4 +8,4 @@ sidebar_label: Settings
 
 Our FAQs section are work-in-progress. Want to contribute? 
 
-Head to the [DAOhaus Discord](https://discord.gg/bUd7HqMx), indicate your role as "Contributor" and reach out! 
+Head to the [DAOhaus Discord](https://discord.gg/HNXHfN8ZUJ), indicate your role as "Contributor" and reach out! 


### PR DESCRIPTION
Discord URL has expired. Updated with: https://discord.gg/HNXHfN8ZUJ