### PR TITLE
Fix typo in bullet point list

### DIFF
--- a/docs/users/profile.mdx
+++ b/docs/users/profile.mdx
@@ -16,5 +16,4 @@ From here you can:
 - View Shares/Loot and Exit Amount (pro-rata claim on banks assets based on current share value)
 - View recent activity within the DAO
 - View and withdraw any internal balances
-- Ragequit :\_(
- 16  docs/profile.mdx 
+- Ragequit


### PR DESCRIPTION
This page: https://daohaus.club/docs/users/profile

Looks like this:
![image](https://user-images.githubusercontent.com/4055501/132966046-cac79e26-f8ed-4806-9574-cc2b37709aaf.png)

My changes make it look like this:
![image](https://user-images.githubusercontent.com/4055501/132966071-0e021ca7-6580-49d0-9b3d-9d37702211b7.png)
