### PR TITLE
fix/docs-compensation-overview

### DIFF
--- a/docs/handbook/contributors/contributors-comp-commit.mdx
+++ b/docs/handbook/contributors/contributors-comp-commit.mdx
@@ -5,13 +5,12 @@ sidebar_label: Commitment Track
 slug: /handbook/contributors/compensation/commitment
 ---
 
-
 ## Commitment Track Compensation Schedule
 
 // TODO: insert comp table
 
 ## Receiving your Commitment Track compensation
 
-Each month, the Paladins will create an steward Disperse proposals to distribute DAI and HAUS compensation from the [Warcamp DAO `Compensation Minion`](https://app.daohaus.club/dao/0x64/0xef3d8c4fbb1860fceab16595db7e650cd5ad51c1/vaults/minion/0x27ad832032022b323efabc260e46aa326c2daad9) directly to Commitment Track contributors. 
+Each month, the Paladins will create an steward Disperse proposals to distribute DAI and HAUS compensation from the [Warcamp DAO `Compensation Minion`](https://app.daohaus.club/dao/0x64/0xef3d8c4fbb1860fceab16595db7e650cd5ad51c1/vaults/minion/0x27ad832032022b323efabc260e46aa326c2daad9) directly to Commitment Track contributors.
 
 These proposals should be created on the 1st of each month, though may be delayed by a couple days depending on when weekends and holidays fall. With Warcamp DAO's 7 day proposal period, you can expect to receive your compensation between the 8th and 10th of each month.


### PR DESCRIPTION
This PR is a quick fix on 2 of the links in the `/compensation/overview` docs page. I was reading through them today and noticed that sometimes on refresh the `/retroactive` and `/commitment` links would sometimes nest inside `/overview` instead of using their slugs.

I switched to use the full relative path and this seems to address it. Here's a screenshot of the issue on our docs:

![daohaus-link-issue](https://user-images.githubusercontent.com/9438776/150664691-5d7190a1-d89a-423f-8ebb-9f8707764251.gif)

